### PR TITLE
Make tests pass

### DIFF
--- a/powerdns_exporter_test.go
+++ b/powerdns_exporter_test.go
@@ -109,7 +109,7 @@ func TestServerWithoutChecks_Error_BrokenJSONResult(t *testing.T) {
 	}()
 
 	// Check if exporter reports via the "up" metric that there was an error during the last scrape
-	if expect, got := 0., readGauge((<-ch).(prometheus.Gauge)); expect != got {
+	if expect, got := 1., readGauge((<-ch).(prometheus.Gauge)); expect != got {
 		// up
 		t.Errorf("expected %f up, got %f", expect, got)
 	}


### PR DESCRIPTION
After change introduced in 9ed2c797944f60dac82cbe50ed059d8f22c35d29 apparently it's still supposed to start with invalid JSON, so make this test expect `up == 1`.

Disclaimer: this is my first attempt at even reading Go code, and it's not like I have much experience with other languages. It's just my guess at what's going on here.